### PR TITLE
Refactor structure of jobs and use job outputs instead of environment values

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-omit =
-  tests/*
-  **/__init__.py

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       prod-hub-matrix-jobs: ${{ steps.generated-jobs.outputs.prod-hub-matrix-jobs }}
       support-and-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.support-and-staging-matrix-jobs }}
-      test: ${{ steps.test-step.outputs.test }}
+
     steps:
       - uses: actions/checkout@v3
 
@@ -50,23 +50,29 @@ jobs:
           # I know, I'm writing the worst Python ever here. I'm just fudging things to get all the workflows running.
           python -m mymodule.helm_upgrade_decision_logic "${{ steps.changed-files.outputs.added_modified }}" --pretty-print
 
-      - id: test-step
-        run: echo "::set-output name=test::hello"
-
   support-staging-jobs:
     runs-on: ubuntu-latest
     needs: generate-jobs
+    strategy:
+      fail-fast: false
+      matrix:
+        jobs: ${{ toJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
     steps:
       - run: |
-          echo ${{ needs.generate-jobs.outputs.test }}
-      - run: |
-          echo ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
+          echo "Provider: ${{ matrix.jobs.provider }}"
+          echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
+          echo "Upgrade support?: ${{ matrix.jobs.upgrade_support }}"
+          echo "Upgrade staging?: ${{ matrix.jobs.upgrade_staging }}"
 
   hub-jobs:
     runs-on: ubuntu-latest
     needs: [generate-jobs, support-staging-jobs]
+    strategy:
+      fail-fast: false
+      matrix:
+        jobs: ${{ toJson(needs.generate-jobs.outputs.prod-hub-matrix-jobs) }}
     steps:
       - run: |
-          echo ${{ needs.generate-jobs.outputs.test }}
-      - run: |
-          echo ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
+          echo "Provider: ${{ matrix.jobs.provider }}"
+          echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
+          echo "Hub name: ${{ matrix.jobs.hub_name }}"

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -18,8 +18,8 @@ jobs:
   generate-jobs:
     runs-on: ubuntu-latest
     outputs:
-      prod-hub-matrix-jobs: ${{ steps.generated-jobs.PROD_HUB_MATRIX_JOBS }}
-      support-staging-matrix-jobs: ${{ steps.generated-jobs.SUPPORT_AND_STAGING_MATRIX_JOBS }}
+      prod-hub-matrix-jobs: ${{ steps.generated-jobs.outputs.PROD_HUB_MATRIX_JOBS }}
+      support-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.SUPPORT_AND_STAGING_MATRIX_JOBS }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobs: ${{ toJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
+        jobs: ${{ fromJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
     steps:
       - run: |
           echo "Provider: ${{ matrix.jobs.provider }}"

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -4,15 +4,15 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "**/*.yaml"
-      - "mymodule/**"
+    # paths:
+    #   - "**/*.yaml"
+    #   - "mymodule/**"
   pull_request:
     branches:
       - main
-    paths:
-      - "**/*.yaml"
-      - "mymodule/**"
+    # paths:
+    #   - "**/*.yaml"
+    #   - "mymodule/**"
 
 jobs:
   generate-jobs:

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       prod-hub-matrix-jobs: ${{ steps.generated-jobs.outputs.PROD_HUB_MATRIX_JOBS }}
       support-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.SUPPORT_AND_STAGING_MATRIX_JOBS }}
+      test: ${{ steps.test-step.outputs.test }}
     steps:
       - uses: actions/checkout@v3
 
@@ -49,10 +50,15 @@ jobs:
           # I know, I'm writing the worst Python ever here. I'm just fudging things to get all the workflows running.
           python -m mymodule.helm_upgrade_decision_logic "${{ steps.changed-files.outputs.added_modified }}" --pretty-print
 
+      - id: test-step
+        run: echo "::set-output name=test::hello"
+
   support-staging-jobs:
     runs-on: ubuntu-latest
     needs: generate-jobs
     steps:
+      - run: |
+          echo ${{ needs.generate-jobs.outputs.test }}
       - run: |
           echo ${{ needs.generate-jobs.outputs.support-staging-matrix-jobs }}
 
@@ -60,5 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-jobs, support-staging-jobs]
     steps:
+      - run: |
+          echo ${{ needs.generate-jobs.outputs.test }}
       - run: |
           echo ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -45,7 +45,7 @@ jobs:
           # I know, I'm writing the worst Python ever here. I'm just fudging things to get all the workflows running.
           python -m mymodule.helm_upgrade_decision_logic "${{ steps.changed-files.outputs.added_modified }}" --pretty-print
 
-  support-jobs:
+  support-staging-jobs:
     runs-on: ubuntu-latest
     needs: generate-jobs
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   hub-jobs:
     runs-on: ubuntu-latest
-    needs: generate-jobs
+    needs: [generate-jobs, support-staging-jobs]
     steps:
       - run: |
           echo ${{ env.HUB_MATRIX_JOBS}}

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -17,6 +17,9 @@ on:
 jobs:
   generate-jobs:
     runs-on: ubuntu-latest
+    outputs:
+      prod-hub-matrix-jobs: ${{ steps.generated-jobs.PROD_HUB_MATRIX_JOBS }}
+      support-staging-matrix-jobs: ${{ steps.generated-jobs.SUPPORT_AND_STAGING_MATRIX_JOBS }}
     steps:
       - uses: actions/checkout@v3
 
@@ -36,6 +39,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run python script
+        id: generated-jobs
         run: |
           # I know, I'm writing the worst Python ever here. I'm just fudging things to get all the workflows running.
           python -m mymodule.helm_upgrade_decision_logic "${{ steps.changed-files.outputs.added_modified }}"
@@ -50,11 +54,11 @@ jobs:
     needs: generate-jobs
     steps:
       - run: |
-          echo ${{ env.SUPPORT_MATRIX_JOBS}}
+          echo ${{ needs.generate-jobs.outputs.support-staging-matrix-jobs }}
 
   hub-jobs:
     runs-on: ubuntu-latest
     needs: [generate-jobs, support-staging-jobs]
     steps:
       - run: |
-          echo ${{ env.HUB_MATRIX_JOBS}}
+          echo ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -1,17 +1,17 @@
-name: Decide which clusters/hubs to run helm upgrade for and create matrix jobs
+name: Deploy hubs
 
 on:
   push:
     branches:
       - main
     paths:
-      - "**.yaml"
+      - "**/*.yaml"
       - "mymodule/**"
   pull_request:
     branches:
       - main
     paths:
-      - "**.yaml"
+      - "**/*.yaml"
       - "mymodule/**"
 
 jobs:

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -53,14 +53,16 @@ jobs:
   support-staging-jobs:
     runs-on: ubuntu-latest
     needs: generate-jobs
-    # strategy:
-    #   fail-fast: false
-    #   matrix:
-    #     jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
+    strategy:
+      fail-fast: false
+      matrix:
+        jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
     steps:
       - run: |
-          echo ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
-          echo ${{ toJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
+          echo "Provider: ${{ matrix.jobs.provider }}"
+          echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
+          echo "Upgrade Support?: ${{ matrix.jobs.upgrade_support }}"
+          echo "Upgrade Staging?: ${{ matrix.jobs.upgrade_staging }}"
 
   # hub-jobs:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prod-hub-matrix-jobs: ${{ steps.generated-jobs.outputs.prod-hub-matrix-jobs }}
-      support-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.support-staging-matrix-jobs }}
+      support-and-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.support-and-staging-matrix-jobs }}
       test: ${{ steps.test-step.outputs.test }}
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
       - run: |
           echo ${{ needs.generate-jobs.outputs.test }}
       - run: |
-          echo ${{ needs.generate-jobs.outputs.support-staging-matrix-jobs }}
+          echo ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
 
   hub-jobs:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -5,23 +5,13 @@ on:
     branches:
       - main
     paths:
-      - "**values.yaml"
-      - "**cluster.yaml"
-      - "helm-charts/basehub/**"
-      - "helm-charts/daskhub/**"
-      - "helm-charts/support/**"
-      - ".github/workflows/**"
+      - "**.yaml"
       - "mymodule/**"
   pull_request:
     branches:
       - main
     paths:
-      - "**values.yaml"
-      - "**cluster.yaml"
-      - "helm-charts/basehub/**"
-      - "helm-charts/daskhub/**"
-      - "helm-charts/support/**"
-      - ".github/workflows/**"
+      - "**.yaml"
       - "mymodule/**"
 
 jobs:

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -18,8 +18,8 @@ jobs:
   generate-jobs:
     runs-on: ubuntu-latest
     outputs:
-      prod-hub-matrix-jobs: ${{ steps.generated-jobs.outputs.PROD_HUB_MATRIX_JOBS }}
-      support-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.SUPPORT_AND_STAGING_MATRIX_JOBS }}
+      prod-hub-matrix-jobs: ${{ steps.generated-jobs.outputs.prod-hub-matrix-jobs }}
+      support-staging-matrix-jobs: ${{ steps.generated-jobs.outputs.support-staging-matrix-jobs }}
       test: ${{ steps.test-step.outputs.test }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobs: ${{ toJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
+        jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
     steps:
       - run: |
           echo "Provider: ${{ matrix.jobs.provider }}"
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobs: ${{ toJson(needs.generate-jobs.outputs.prod-hub-matrix-jobs) }}
+        jobs: ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
     steps:
       - run: |
           echo "Provider: ${{ matrix.jobs.provider }}"

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -4,15 +4,15 @@ on:
   push:
     branches:
       - main
-    # paths:
-    #   - "**/*.yaml"
-    #   - "mymodule/**"
+    paths:
+      - "**/*.yaml"
+      - "mymodule/**"
   pull_request:
     branches:
       - main
-    # paths:
-    #   - "**/*.yaml"
-    #   - "mymodule/**"
+    paths:
+      - "**/*.yaml"
+      - "mymodule/**"
 
 jobs:
   generate-jobs:

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
+        jobs: ${{ toJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
     steps:
       - run: |
           echo "Provider: ${{ matrix.jobs.provider }}"

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -64,15 +64,15 @@ jobs:
           echo "Upgrade Support?: ${{ matrix.jobs.upgrade_support }}"
           echo "Upgrade Staging?: ${{ matrix.jobs.upgrade_staging }}"
 
-  # hub-jobs:
-  #   runs-on: ubuntu-latest
-  #   needs: [generate-jobs, support-staging-jobs]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       jobs: ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
-  #   steps:
-  #     - run: |
-  #         echo "Provider: ${{ matrix.jobs.provider }}"
-  #         echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
-  #         echo "Hub name: ${{ matrix.jobs.hub_name }}"
+  hub-jobs:
+    runs-on: ubuntu-latest
+    needs: [generate-jobs, support-staging-jobs]
+    strategy:
+      fail-fast: false
+      matrix:
+        jobs: ${{ fromJson(needs.generate-jobs.outputs.prod-hub-matrix-jobs) }}
+    steps:
+      - run: |
+          echo "Provider: ${{ matrix.jobs.provider }}"
+          echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
+          echo "Hub name: ${{ matrix.jobs.hub_name }}"

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -53,26 +53,24 @@ jobs:
   support-staging-jobs:
     runs-on: ubuntu-latest
     needs: generate-jobs
-    strategy:
-      fail-fast: false
-      matrix:
-        jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     jobs: ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
     steps:
       - run: |
-          echo "Provider: ${{ matrix.jobs.provider }}"
-          echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
-          echo "Upgrade support?: ${{ matrix.jobs.upgrade_support }}"
-          echo "Upgrade staging?: ${{ matrix.jobs.upgrade_staging }}"
+          echo ${{ needs.generate-jobs.outputs.support-and-staging-matrix-jobs }}
+          echo ${{ toJson(needs.generate-jobs.outputs.support-and-staging-matrix-jobs) }}
 
-  hub-jobs:
-    runs-on: ubuntu-latest
-    needs: [generate-jobs, support-staging-jobs]
-    strategy:
-      fail-fast: false
-      matrix:
-        jobs: ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
-    steps:
-      - run: |
-          echo "Provider: ${{ matrix.jobs.provider }}"
-          echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
-          echo "Hub name: ${{ matrix.jobs.hub_name }}"
+  # hub-jobs:
+  #   runs-on: ubuntu-latest
+  #   needs: [generate-jobs, support-staging-jobs]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       jobs: ${{ needs.generate-jobs.outputs.prod-hub-matrix-jobs }}
+  #   steps:
+  #     - run: |
+  #         echo "Provider: ${{ matrix.jobs.provider }}"
+  #         echo "Cluster name: ${{ matrix.jobs.cluster_name }}"
+  #         echo "Hub name: ${{ matrix.jobs.hub_name }}"

--- a/.github/workflows/helm-upgrade-decision-logic.yaml
+++ b/.github/workflows/helm-upgrade-decision-logic.yaml
@@ -11,6 +11,7 @@ on:
       - "helm-charts/daskhub/**"
       - "helm-charts/support/**"
       - ".github/workflows/**"
+      - "mymodule/**"
   pull_request:
     branches:
       - main
@@ -21,9 +22,10 @@ on:
       - "helm-charts/daskhub/**"
       - "helm-charts/support/**"
       - ".github/workflows/**"
+      - "mymodule/**"
 
 jobs:
-  filepaths:
+  generate-jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,15 +50,21 @@ jobs:
           # I know, I'm writing the worst Python ever here. I'm just fudging things to get all the workflows running.
           python -m mymodule.helm_upgrade_decision_logic "${{ steps.changed-files.outputs.added_modified }}"
 
-      - name: Echo hub matrix jobs
-        run: |
-          echo ${{ toJson(env.HUB_MATRIX_JOBS) }}
-
-      - name: Echo support matrix jobs
-        run: |
-          echo ${{ toJson(env.SUPPORT_MATRIX_JOBS) }}
-
       - name: Run python script with pretty-print
         run: |
           # I know, I'm writing the worst Python ever here. I'm just fudging things to get all the workflows running.
           python -m mymodule.helm_upgrade_decision_logic "${{ steps.changed-files.outputs.added_modified }}" --pretty-print
+
+  support-jobs:
+    runs-on: ubuntu-latest
+    needs: generate-jobs
+    steps:
+      - run: |
+          echo ${{ env.SUPPORT_MATRIX_JOBS}}
+
+  hub-jobs:
+    runs-on: ubuntu-latest
+    needs: generate-jobs
+    steps:
+      - run: |
+          echo ${{ env.HUB_MATRIX_JOBS}}

--- a/.github/workflows/test-deployer.yaml
+++ b/.github/workflows/test-deployer.yaml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
     paths:
-      - "**.py"
+      - "mymodule/**"
       - "tests/**"
   pull_request:
     branches:
       - main
     paths:
-      - "**.py"
+      - "mymodule/**"
       - "tests/**"
 
 jobs:

--- a/.github/workflows/test-deployer.yaml
+++ b/.github/workflows/test-deployer.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install ruamel.yaml rich pytest pytest-env
+          python -m pip install ruamel.yaml rich pytest
       - name: Run tests
         run: |
           python -m pytest -vvv --color=yes

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -550,7 +550,7 @@ def main():
         pretty_print_matrix_jobs(prod_hub_matrix_jobs, support_and_staging_matrix_jobs)
     else:
         # Add these matrix jobs as output variables for use in another job
-        # https://docs.github.com/en/github-ae@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
         print(f"::set-output name=prod-hub-matrix-jobs::{prod_hub_matrix_jobs}")
         print(f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}")
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -325,7 +325,7 @@ def assign_staging_matrix_jobs(
                     "provider": hub_job["provider"],
                     "upgrade_staging": "true",
                     "reason_for_staging_redeploy": hub_job["reason_for_redeploy"],
-                    "upgrade_support": False,
+                    "upgrade_support": "false",
                     "reason_for_support_redeploy": "",
                 }
                 staging_matrix_jobs.append(new_job)
@@ -359,7 +359,7 @@ def assign_staging_matrix_jobs(
             else:
                 # There are no prod hubs on this cluster that require an upgrade, so we
                 # do not upgrade staging
-                staging_job["upgrade_staging"] = False
+                staging_job["upgrade_staging"] = "false"
                 staging_job["reason_for_staging_redeploy"] = ""
 
     # Ensure that for each cluster listed in hub_matrix_jobs, there is an associated job
@@ -393,7 +393,7 @@ def assign_staging_matrix_jobs(
             new_job = {
                 "cluster_name": missing_cluster,
                 "provider": provider,
-                "upgrade_support": False,
+                "upgrade_support": "false",
                 "reason_for_support_redeploy": "",
                 "upgrade_staging": "true",
                 "reason_for_staging_redeploy": (

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -42,11 +42,9 @@ def discover_modified_common_files(modified_paths: list):
     # If any of the following filepaths have changed, we should update all hubs on all clusters
     common_filepaths = [
         # Filepaths related to the deployer infrastructure
-        "deployer/*",
-        "requirements.txt",
+        "mymodule/*",
         # Filepaths related to GitHub Actions infrastructure
-        ".github/workflows/deploy-hubs.yaml",
-        ".github/actions/deploy/*",
+        ".github/workflows/*",
         # Filepaths related to helm chart infrastructure
         "helm-charts/basehub/*",
         "helm-charts/daskhub/*",

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -555,13 +555,13 @@ def main():
         subprocess.check_call(
             [
                 "echo",
-                f'"::set-output name=prod-hub-matrix-jobs::{yaml.dumps(prod_hub_matrix_jobs)}"',
+                f'"::set-output name=prod-hub-matrix-jobs::{yaml.dump(prod_hub_matrix_jobs)}"',
             ]
         )
         subprocess.check_call(
             [
                 "echo",
-                f'"::set-output name=support-and-staging-matrix-jobs::{yaml.dumps(support_and_staging_matrix_jobs)}"',
+                f'"::set-output name=support-and-staging-matrix-jobs::{yaml.dump(support_and_staging_matrix_jobs)}"',
             ]
         )
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -2,15 +2,12 @@ import argparse
 import fnmatch
 import os
 from pathlib import Path
-from ruamel.yaml import YAML
+
 from rich.console import Console
 from rich.table import Table
+from ruamel.yaml import YAML
 
 yaml = YAML(typ="safe", pure=True)
-
-# Determine if we are running a test or not. We set this env var to "test" in the
-# pyproject.toml file so it is set when the package is tested using pytest.
-test_env = os.getenv("RUN_ENV", False)
 
 
 def _converted_string_to_list(full_str: str) -> list:
@@ -69,48 +66,38 @@ def discover_modified_common_files(modified_paths: list):
     return upgrade_support_on_all_clusters, upgrade_all_hubs_on_all_clusters
 
 
-def get_unique_cluster_filepaths(added_or_modified_files: list):
-    """For a list of added and modified files, get the list of unique filepaths to
-    cluster folders containing added/modified files
-
-    Note: "cluster folders" are those that contain a cluster.yaml file.
+def get_all_cluster_yaml_files(test_env: bool = False) -> set:
+    """Get a set of absolute paths to all cluster.yaml files in the repository
 
     Args:
-        added_or_modified_files (list[str]): A list of files that have been added or
-            modified in a GitHub Pull Request
+        test_env (bool, optional): A flag to determine whether we are running a test
+            suite or not. If True, only return the paths to cluster.yaml files under the
+            'tests/' directory. If False, explicitly exclude the cluster.yaml files
+            nested under the 'tests/' directory. Defaults to False.
 
     Returns:
-        list[path obj]: A list of unique filepaths to cluster folders
+        set[path obj]: A set of absolute paths to all cluster.yaml files in the repo
     """
     # Get absolute paths
-    if test_env == "test":
+    if test_env:
         # We are running a test via pytest. We only want to focus on the cluster
         # folders nested under the `tests/` folder.
-        filepaths = [
-            Path(filepath).parent
-            for filepath in added_or_modified_files
-            if Path(filepath).parent.joinpath("cluster.yaml").is_file()
-            if "tests/" in filepath
+        cluster_files = [
+            filepath
+            for filepath in Path(os.getcwd()).glob("**/cluster.yaml")
+            if "tests" in str(filepath)
         ]
     else:
         # We are NOT running a test via pytest. We want to explicitly ignore the
         # cluster folders nested under the `tests/` folder.
-        filepaths = [
-            Path(filepath).parent
-            for filepath in added_or_modified_files
-            if Path(filepath).parent.joinpath("cluster.yaml").is_file()
-            if "tests/" not in filepath
+        cluster_files = [
+            filepath
+            for filepath in Path(os.getcwd()).glob("**/cluster.yaml")
+            if "tests" not in str(filepath)
         ]
 
-    # Get unique absolute paths
-    filepaths = list(set(filepaths))
-
-    # Check these filepaths are cluster folders by the existence of a cluster.yaml file
-    for filepath in filepaths:
-        if not filepath.joinpath("cluster.yaml").is_file():
-            filepaths.remove(filepath)
-
-    return filepaths
+    # Return unique absolute paths
+    return set(cluster_files)
 
 
 def generate_hub_matrix_jobs(

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -101,124 +101,77 @@ def get_all_cluster_yaml_files(test_env: bool = False) -> set:
 
 
 def generate_hub_matrix_jobs(
-    cluster_filepaths,
-    added_or_modified_files,
-    upgrade_all_hubs_on_all_clusters=False,
-):
-    """Generate a list of dictionaries describing which hubs on which clusters need
+    cluster_file: Path,
+    cluster_config: dict,
+    cluster_info: dict,
+    added_or_modified_files: set,
+    upgrade_all_hubs_on_this_cluster: bool = False,
+    upgrade_all_hubs_on_all_clusters: bool = False,
+) -> list:
+    """Generate a list of dictionaries describing which hubs on a given cluster need
     to undergo a helm upgrade based on whether their associated helm chart values
     files have been modified. To be parsed to GitHub Actions in order to generate
     parallel jobs in a matrix.
 
-    Note: "cluster folders" are those that contain a cluster.yaml file.
-
     Args:
-        cluster_filepaths (list[path obj]): List of absolute paths to cluster folders
+        cluster_file (path obj): The absolute path to the cluster.yaml file of a given
+            cluster
+        cluster_config (dict): The cluster-wide config for a given cluster in
+            dictionary format
+        cluster_info (dict): A template dictionary for defining matrix jobs prepopulated
+            with some info. "cluster_name": The name of the given cluster; "provider":
+            the cloud provider the given cluster runs on; "reason_for_redeploy":
+            what has changed in the repository to prompt a hub on this cluster to be
+            redeployed.
         added_or_modified_files (set[str]): A set of all added or modified files
             provided in a GitHub Pull Requests
+        upgrade_all_hubs_on_this_cluster (bool, optional): If True, generates jobs to
+            upgrade all hubs on the given cluster. This is triggered when the
+            cluster.yaml file itself has been modified. Defaults to False.
         upgrade_all_hubs_on_all_clusters (bool, optional): If True, generates jobs to
             upgrade all hubs on all clusters. This is triggered when common config has
-            been modified, such as basehub or daskhub helm charts. Defaults to False.
+            been modified, such as the basehub or daskhub helm charts. Defaults to False.
 
     Returns:
         list[dict]: A list of dictionaries. Each dictionary contains: the name of a
-            cluster, the cloud provider that cluster runs on, and the name of a hub
-            deployed to that cluster.
+            cluster, the cloud provider that cluster runs on, the name of a hub
+            deployed to that cluster, and the reason that hub needs to be redeployed.
     """
-    # Empty list to store the matrix job definitions in
+    # Empty list to store all the matrix job definitions in
     matrix_jobs = []
 
-    # This flag will allow us to establish when a cluster.yaml file has been updated
-    # and all hubs on that cluster should be upgraded, without also upgrading all hubs
-    # on all other clusters
-    upgrade_all_hubs_on_this_cluster = False
+    # Loop over each hub on this cluster
+    for hub in cluster_config.get("hubs", {}):
+        if upgrade_all_hubs_on_all_clusters or upgrade_all_hubs_on_this_cluster:
+            # We know we're upgrading all hubs, so just add the hub name to the list
+            # of matrix jobs and move on
+            matrix_job = cluster_info.copy()
+            matrix_job["hub_name"] = hub["name"]
+            matrix_jobs.append(matrix_job)
 
-    if upgrade_all_hubs_on_all_clusters:
-        print(
-            "Core infrastrucure has been modified. Generating jobs to upgrade all hubs on ALL clusters."
-        )
-        reason_for_redeploy = "Core infrastructure has changed"
-
-        # Overwrite cluster_filepaths to contain paths to all clusters
-        if test_env == "test":
-            # We are running a test via pytest. We only want to focus on the cluster
-            # folders nested under the `tests/` folder.
-            cluster_filepaths = [
-                filepath.parent
-                for filepath in Path(os.getcwd()).glob("**/cluster.yaml")
-                if "tests/" in str(filepath)
-            ]
         else:
-            # We are NOT running a test via pytest. We want to explicitly ignore the
-            # cluster folders nested under the `tests/` folder.
-            cluster_filepaths = [
-                filepath.parent
-                for filepath in Path(os.getcwd()).glob("**/cluster.yaml")
-                if "tests/" not in str(filepath)
+            # Read in this hub's helm chart values files from the cluster.yaml file
+            helm_chart_values_files = [
+                str(cluster_file.parent.joinpath(values_file))
+                for values_file in hub.get("helm_chart_values_files", {})
             ]
-
-    for cluster_filepath in cluster_filepaths:
-        # Read in the cluster.yaml file
-        with open(cluster_filepath.joinpath("cluster.yaml")) as f:
-            cluster_config = yaml.load(f)
-
-        if not upgrade_all_hubs_on_all_clusters:
-            # Check if this cluster file has been modified. If so, set
-            # upgrade_all_hubs_on_this_cluster to True
-            intersection = added_or_modified_files.intersection(
-                [str(cluster_filepath.joinpath("cluster.yaml"))]
+            # Establish if any of this hub's helm chart values files have been
+            # modified
+            intersection = list(
+                added_or_modified_files.intersection(helm_chart_values_files)
             )
-            if len(intersection) > 0:
-                print(
-                    f"This cluster.yaml file has been modified. Generating jobs to upgrade all hubs on THIS cluster: {cluster_config.get('name', {})}"
-                )
-                upgrade_all_hubs_on_this_cluster = True
-                reason_for_redeploy = "cluster.yaml file was modified"
 
-        # Generate template dictionary for all jobs associated with this cluster
-        cluster_info = {
-            "cluster_name": cluster_config.get("name", {}),
-            "provider": cluster_config.get("provider", {}),
-        }
-
-        # Loop over each hub on this cluster
-        for hub in cluster_config.get("hubs", {}):
-            if upgrade_all_hubs_on_all_clusters or upgrade_all_hubs_on_this_cluster:
-                # We know we're upgrading all hubs, so just add the hub name to the list
-                # of matrix jobs and move on
+            if intersection:
+                # If at least one of the helm chart values files associated with
+                # this hub has been modified, add it to list of matrix jobs to be
+                # upgraded
                 matrix_job = cluster_info.copy()
                 matrix_job["hub_name"] = hub["name"]
-                matrix_job["reason_for_redeploy"] = reason_for_redeploy
-                matrix_jobs.append(matrix_job)
-
-            else:
-                # Read in this hub's helm chart values files from the cluster.yaml file
-                helm_chart_values_files = [
-                    str(cluster_filepath.joinpath(values_file))
-                    for values_file in hub.get("helm_chart_values_files", {})
-                ]
-                # Establish if any of this hub's helm chart values files have been
-                # modified
-                intersection = list(
-                    added_or_modified_files.intersection(helm_chart_values_files)
+                matrix_job["reason_for_redeploy"] = (
+                    "Following helm chart values files were modified:\n- "
+                    + "\n- ".join(intersection)
                 )
-
-                if len(intersection) > 0:
-                    # If at least one of the helm chart values files associated with
-                    # this hub has been modified, add it to list of matrix jobs to be
-                    # upgraded
-                    reason_for_redeploy = (
-                        "Following helm chart values files were modified:\n"
-                        + "\n- ".join(intersection)
-                    )
-
-                    matrix_job = cluster_info.copy()
-                    matrix_job["hub_name"] = hub["name"]
-                    matrix_job["reason_for_redeploy"] = reason_for_redeploy
-                    matrix_jobs.append(matrix_job)
-
-        # Reset upgrade_all_hubs_on_this_cluster for the next iteration
-        upgrade_all_hubs_on_this_cluster = False
+                matrix_jobs.append(matrix_job)
 
     return matrix_jobs
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -226,7 +226,7 @@ def generate_support_matrix_jobs(
             # We know we're upgrading support on all clusters, so just add the cluster
             # name to the list of matrix jobs and move on
             matrix_job = cluster_info.copy()
-            matrix_job["upgrade_support"] = True
+            matrix_job["upgrade_support"] = "true"
             matrix_job[
                 "reason_for_support_redeploy"
             ] = "Support helm chart has been modified"
@@ -242,7 +242,7 @@ def generate_support_matrix_jobs(
 
             if intersection:
                 matrix_job = cluster_info.copy()
-                matrix_job["upgrade_support"] = True
+                matrix_job["upgrade_support"] = "true"
                 matrix_job["reason_for_support_redeploy"] = (
                     "Following helm chart values files were modified:\n- "
                     + "\n- ".join([path.name for path in intersection])
@@ -307,7 +307,7 @@ def assign_staging_matrix_jobs(
             if job_idx is not None:
                 # Add information to the matching staging_matrix_jobs entry
                 # to upgrade the staging deployment
-                staging_matrix_jobs[job_idx]["upgrade_staging"] = True
+                staging_matrix_jobs[job_idx]["upgrade_staging"] = "true"
                 staging_matrix_jobs[job_idx]["reason_for_staging_redeploy"] = hub_job[
                     "reason_for_redeploy"
                 ]
@@ -323,7 +323,7 @@ def assign_staging_matrix_jobs(
                 new_job = {
                     "cluster_name": hub_job["cluster_name"],
                     "provider": hub_job["provider"],
-                    "upgrade_staging": True,
+                    "upgrade_staging": "true",
                     "reason_for_staging_redeploy": hub_job["reason_for_redeploy"],
                     "upgrade_support": False,
                     "reason_for_support_redeploy": "",
@@ -350,7 +350,7 @@ def assign_staging_matrix_jobs(
             if hubs_on_this_cluster:
                 # There are prod hubs on this cluster that require an upgrade, and so we
                 # also upgrade staging
-                staging_job["upgrade_staging"] = True
+                staging_job["upgrade_staging"] = "true"
                 staging_job[
                     "reason_for_staging_redeploy"
                 ] = "Following prod hubs require redeploy:\n- " + "\n- ".join(
@@ -395,7 +395,7 @@ def assign_staging_matrix_jobs(
                 "provider": provider,
                 "upgrade_support": False,
                 "reason_for_support_redeploy": "",
-                "upgrade_staging": True,
+                "upgrade_staging": "true",
                 "reason_for_staging_redeploy": (
                     "Following prod hubs require redeploy:\n- " + "\n- ".join(prod_hubs)
                 ),
@@ -423,9 +423,9 @@ def pretty_print_matrix_jobs(
         support_table.add_row(
             job["provider"],
             job["cluster_name"],
-            str(job["upgrade_support"]),
+            job["upgrade_support"],
             job["reason_for_support_redeploy"],
-            str(job["upgrade_staging"]),
+            job["upgrade_staging"],
             job["reason_for_staging_redeploy"],
         )
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -436,28 +436,36 @@ def update_github_env(hub_matrix_jobs, support_matrix_jobs):
         )
 
 
-def pretty_print_matrix_jobs(hub_matrix_jobs, support_matrix_jobs):
+def pretty_print_matrix_jobs(prod_hub_matrix_jobs: list, support_and_staging_matrix_jobs: list) -> None:
     # Construct table for support chart upgrades
-    support_table = Table(title="Support chart upgrades")
+    support_table = Table(title="Support chart and Staging hub upgrades")
     support_table.add_column("Cloud Provider")
     support_table.add_column("Cluster Name")
-    support_table.add_column("Reason for Redeploy")
+    support_table.add_column("Upgrade Support?")
+    support_table.add_column("Reason for Support Redeploy")
+    support_table.add_column("Upgrade Staging?")
+    support_table.add_column("Reason for Staging Redeploy")
 
     # Add rows
-    for job in support_matrix_jobs:
+    for job in support_and_staging_matrix_jobs:
         support_table.add_row(
-            job["provider"], job["cluster_name"], job["reason_for_redeploy"]
+            job["provider"],
+            job["cluster_name"],
+            str(job["upgrade_support"]),
+            job["reason_for_support_redeploy"],
+            str(job["upgrade_staging"]),
+            job["reason_for_staging_redeploy"],
         )
 
-    # Construct table for hub helm chart upgrades
-    hub_table = Table(title="Hub helm chart upgrades")
+    # Construct table for prod hub upgrades
+    hub_table = Table(title="Prod hub upgrades")
     hub_table.add_column("Cloud Provider")
     hub_table.add_column("Cluster Name")
     hub_table.add_column("Hub Name")
     hub_table.add_column("Reason for Redeploy")
 
     # Add rows
-    for job in hub_matrix_jobs:
+    for job in prod_hub_matrix_jobs:
         hub_table.add_row(
             job["provider"],
             job["cluster_name"],

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -325,7 +325,7 @@ def assign_staging_matrix_jobs(
                     "provider": hub_job["provider"],
                     "upgrade_staging": True,
                     "reason_for_staging_redeploy": hub_job["reason_for_redeploy"],
-                    "upgrade_support": "false",
+                    "upgrade_support": False,
                     "reason_for_support_redeploy": "",
                 }
                 staging_matrix_jobs.append(new_job)
@@ -359,7 +359,7 @@ def assign_staging_matrix_jobs(
             else:
                 # There are no prod hubs on this cluster that require an upgrade, so we
                 # do not upgrade staging
-                staging_job["upgrade_staging"] = "false"
+                staging_job["upgrade_staging"] = False
                 staging_job["reason_for_staging_redeploy"] = ""
 
     # Ensure that for each cluster listed in hub_matrix_jobs, there is an associated job
@@ -393,7 +393,7 @@ def assign_staging_matrix_jobs(
             new_job = {
                 "cluster_name": missing_cluster,
                 "provider": provider,
-                "upgrade_support": "false",
+                "upgrade_support": False,
                 "reason_for_support_redeploy": "",
                 "upgrade_staging": True,
                 "reason_for_staging_redeploy": (

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -473,7 +473,7 @@ def main():
     ) = discover_modified_common_files(args.filepaths)
 
     # Get a list of filepaths to target cluster folders
-    cluster_files = get_all_cluster_yaml_files(args.filepaths)
+    cluster_files = get_all_cluster_yaml_files()
 
     # Empty lists to store job definitions in
     prod_hub_matrix_jobs = []

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -228,7 +228,9 @@ def generate_support_matrix_jobs(
             # name to the list of matrix jobs and move on
             matrix_job = cluster_info.copy()
             matrix_job["upgrade_support"] = True
-            matrix_job["reason_for_support_redeploy"] = "Support helm chart has been modified"
+            matrix_job[
+                "reason_for_support_redeploy"
+            ] = "Support helm chart has been modified"
             matrix_jobs.append(matrix_job)
 
         else:

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -226,7 +226,7 @@ def generate_support_matrix_jobs(
             # We know we're upgrading support on all clusters, so just add the cluster
             # name to the list of matrix jobs and move on
             matrix_job = cluster_info.copy()
-            matrix_job["upgrade_support"] = "true"
+            matrix_job["upgrade_support"] = True
             matrix_job[
                 "reason_for_support_redeploy"
             ] = "Support helm chart has been modified"
@@ -242,7 +242,7 @@ def generate_support_matrix_jobs(
 
             if intersection:
                 matrix_job = cluster_info.copy()
-                matrix_job["upgrade_support"] = "true"
+                matrix_job["upgrade_support"] = True
                 matrix_job["reason_for_support_redeploy"] = (
                     "Following helm chart values files were modified:\n- "
                     + "\n- ".join([path.name for path in intersection])
@@ -307,7 +307,7 @@ def assign_staging_matrix_jobs(
             if job_idx is not None:
                 # Add information to the matching staging_matrix_jobs entry
                 # to upgrade the staging deployment
-                staging_matrix_jobs[job_idx]["upgrade_staging"] = "true"
+                staging_matrix_jobs[job_idx]["upgrade_staging"] = True
                 staging_matrix_jobs[job_idx]["reason_for_staging_redeploy"] = hub_job[
                     "reason_for_redeploy"
                 ]
@@ -323,7 +323,7 @@ def assign_staging_matrix_jobs(
                 new_job = {
                     "cluster_name": hub_job["cluster_name"],
                     "provider": hub_job["provider"],
-                    "upgrade_staging": "true",
+                    "upgrade_staging": True,
                     "reason_for_staging_redeploy": hub_job["reason_for_redeploy"],
                     "upgrade_support": "false",
                     "reason_for_support_redeploy": "",
@@ -350,7 +350,7 @@ def assign_staging_matrix_jobs(
             if hubs_on_this_cluster:
                 # There are prod hubs on this cluster that require an upgrade, and so we
                 # also upgrade staging
-                staging_job["upgrade_staging"] = "true"
+                staging_job["upgrade_staging"] = True
                 staging_job[
                     "reason_for_staging_redeploy"
                 ] = "Following prod hubs require redeploy:\n- " + "\n- ".join(
@@ -395,7 +395,7 @@ def assign_staging_matrix_jobs(
                 "provider": provider,
                 "upgrade_support": "false",
                 "reason_for_support_redeploy": "",
-                "upgrade_staging": "true",
+                "upgrade_staging": True,
                 "reason_for_staging_redeploy": (
                     "Following prod hubs require redeploy:\n- " + "\n- ".join(prod_hubs)
                 ),
@@ -423,9 +423,9 @@ def pretty_print_matrix_jobs(
         support_table.add_row(
             job["provider"],
             job["cluster_name"],
-            job["upgrade_support"],
+            str(job["upgrade_support"]),
             job["reason_for_support_redeploy"],
-            job["upgrade_staging"],
+            str(job["upgrade_staging"]),
             job["reason_for_staging_redeploy"],
         )
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -149,7 +149,9 @@ def generate_hub_matrix_jobs(
             matrix_job["hub_name"] = hub["name"]
 
             if upgrade_all_hubs_on_all_clusters:
-                cluster_info["reason_for_redeploy"] = "Core infrastructure has been modified"
+                cluster_info[
+                    "reason_for_redeploy"
+                ] = "Core infrastructure has been modified"
 
             matrix_jobs.append(matrix_job)
 
@@ -169,9 +171,10 @@ def generate_hub_matrix_jobs(
                 # upgraded
                 matrix_job = cluster_info.copy()
                 matrix_job["hub_name"] = hub["name"]
-                matrix_job["reason_for_redeploy"] = (
-                    "Following helm chart values files were modified: "
-                    + ", ".join([path.name for path in intersection])
+                matrix_job[
+                    "reason_for_redeploy"
+                ] = "Following helm chart values files were modified: " + ", ".join(
+                    [path.name for path in intersection]
                 )
                 matrix_jobs.append(matrix_job)
 
@@ -250,9 +253,10 @@ def generate_support_matrix_jobs(
             if intersection:
                 matrix_job = cluster_info.copy()
                 matrix_job["upgrade_support"] = "true"
-                matrix_job["reason_for_support_redeploy"] = (
-                    "Following helm chart values files were modified: "
-                    + ", ".join([path.name for path in intersection])
+                matrix_job[
+                    "reason_for_support_redeploy"
+                ] = "Following helm chart values files were modified: " + ", ".join(
+                    [path.name for path in intersection]
                 )
                 matrix_jobs.append(matrix_job)
 
@@ -561,7 +565,9 @@ def main():
         # Add these matrix jobs as output variables for use in another job
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
         print(f"::set-output name=prod-hub-matrix-jobs::{prod_hub_matrix_jobs}")
-        print(f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}")
+        print(
+            f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}"
+        )
 
 
 if __name__ == "__main__":

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -89,6 +89,7 @@ def get_unique_cluster_filepaths(added_or_modified_files: list):
         filepaths = [
             Path(filepath).parent
             for filepath in added_or_modified_files
+            if Path(filepath).parent.joinpath("cluster.yaml").is_file()
             if "tests/" in filepath
         ]
     else:
@@ -97,6 +98,7 @@ def get_unique_cluster_filepaths(added_or_modified_files: list):
         filepaths = [
             Path(filepath).parent
             for filepath in added_or_modified_files
+            if Path(filepath).parent.joinpath("cluster.yaml").is_file()
             if "tests/" not in filepath
         ]
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -307,9 +307,9 @@ def assign_staging_matrix_jobs(
                 # Add information to the matching staging_matrix_jobs entry
                 # to upgrade the staging deployment
                 staging_matrix_jobs[job_idx]["upgrade_staging"] = True
-                staging_matrix_jobs[job_idx][
-                    "reason_for_staging_redeploy"
-                ] = hub_job["reason_for_redeploy"]
+                staging_matrix_jobs[job_idx]["reason_for_staging_redeploy"] = hub_job[
+                    "reason_for_redeploy"
+                ]
 
                 # Mark the current hub job for deletion from hub_matrix_jobs
                 job_ids_to_remove.append(hub_job_id)
@@ -365,9 +365,7 @@ def assign_staging_matrix_jobs(
     # in staging_matrix_jobs. This is our last-hope catch-all to ensure there are no
     # prod hub jobs trying to run without an associated support/staging job
     prod_hub_clusters = {job["cluster_name"] for job in hub_matrix_jobs}
-    support_staging_clusters = {
-        job["cluster_name"] for job in staging_matrix_jobs
-    }
+    support_staging_clusters = {job["cluster_name"] for job in staging_matrix_jobs}
     missing_clusters = prod_hub_clusters.difference(support_staging_clusters)
 
     if missing_clusters:
@@ -436,7 +434,9 @@ def update_github_env(hub_matrix_jobs, support_matrix_jobs):
         )
 
 
-def pretty_print_matrix_jobs(prod_hub_matrix_jobs: list, support_and_staging_matrix_jobs: list) -> None:
+def pretty_print_matrix_jobs(
+    prod_hub_matrix_jobs: list, support_and_staging_matrix_jobs: list
+) -> None:
     # Construct table for support chart upgrades
     support_table = Table(title="Support chart and Staging hub upgrades")
     support_table.add_column("Cloud Provider")

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -21,7 +21,7 @@ def _converted_string_to_list(full_str: str) -> list:
     return full_str.split(" ")
 
 
-def discover_modified_common_files(modified_paths: list):
+def discover_modified_common_files(modified_paths: list) -> (bool, bool):
     """There are certain common files which, if modified, we should upgrade all hubs
     and/or all clusters appropriately. These common files include the helm charts we
     deploy, as well as the GitHub Actions and deployer package we use to deploy them.

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -434,6 +434,7 @@ def pretty_print_matrix_jobs(
             job["reason_for_support_redeploy"],
             job["upgrade_staging"],
             job["reason_for_staging_redeploy"],
+            end_section=True,
         )
 
     # Construct table for prod hub upgrades
@@ -450,6 +451,7 @@ def pretty_print_matrix_jobs(
             job["cluster_name"],
             job["hub_name"],
             job["reason_for_redeploy"],
+            end_section=True,
         )
 
     console = Console()

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -555,13 +555,13 @@ def main():
         subprocess.check_call(
             [
                 "echo",
-                f'"::set-output name=prod-hub-matrix-jobs::{yaml.dump(prod_hub_matrix_jobs)}"',
+                f"::set-output name=prod-hub-matrix-jobs::{prod_hub_matrix_jobs}",
             ]
         )
         subprocess.check_call(
             [
                 "echo",
-                f'"::set-output name=support-and-staging-matrix-jobs::{yaml.dump(support_and_staging_matrix_jobs)}"',
+                f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}",
             ]
         )
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -595,10 +595,18 @@ def main():
             )
         )
 
-    # this needs to be a better comment v
-    # Ensure that the matrix job definitions conform to schema
-    prod_hub_matrix_jobs, support_and_staging_matrix_jobs = assign_staging_matrix_jobs(
+    # Clean up the matrix jobs
+    (
+        prod_hub_matrix_jobs,
+        support_and_staging_matrix_jobs,
+    ) = move_staging_jobs_to_staging_matrix(
         prod_hub_matrix_jobs, support_and_staging_matrix_jobs
+    )
+    support_and_staging_matrix_jobs = ensure_support_staging_jobs_have_correct_keys(
+        support_and_staging_matrix_jobs, prod_hub_matrix_jobs
+    )
+    support_and_staging_matrix_jobs = assign_staging_jobs_for_missing_clusters(
+        support_and_staging_matrix_jobs, prod_hub_matrix_jobs
     )
 
     # The existence of the CI environment variable is an indication that we are running

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -1,7 +1,6 @@
 import argparse
 import fnmatch
 import os
-import subprocess
 from pathlib import Path
 
 from rich.console import Console
@@ -552,18 +551,8 @@ def main():
     else:
         # Add these matrix jobs as output variables for use in another job
         # https://docs.github.com/en/github-ae@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
-        subprocess.check_call(
-            [
-                "echo",
-                f"::set-output name=prod-hub-matrix-jobs::{prod_hub_matrix_jobs}",
-            ]
-        )
-        subprocess.check_call(
-            [
-                "echo",
-                f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}",
-            ]
-        )
+        print(f"::set-output name=prod-hub-matrix-jobs::{prod_hub_matrix_jobs}")
+        print(f"::set-output name=support-and-staging-matrix-jobs::{support_and_staging_matrix_jobs}")
 
 
 if __name__ == "__main__":

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -149,7 +149,7 @@ def generate_hub_matrix_jobs(
             matrix_job["hub_name"] = hub["name"]
 
             if upgrade_all_hubs_on_all_clusters:
-                cluster_info[
+                matrix_job[
                     "reason_for_redeploy"
                 ] = "Core infrastructure has been modified"
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -147,6 +147,10 @@ def generate_hub_matrix_jobs(
             # of matrix jobs and move on
             matrix_job = cluster_info.copy()
             matrix_job["hub_name"] = hub["name"]
+
+            if upgrade_all_hubs_on_all_clusters:
+                cluster_info["reason_for_redeploy"] = "Core infrastructure has been modified"
+
             matrix_jobs.append(matrix_job)
 
         else:
@@ -166,8 +170,8 @@ def generate_hub_matrix_jobs(
                 matrix_job = cluster_info.copy()
                 matrix_job["hub_name"] = hub["name"]
                 matrix_job["reason_for_redeploy"] = (
-                    "Following helm chart values files were modified:\n- "
-                    + "\n- ".join([path.name for path in intersection])
+                    "Following helm chart values files were modified: "
+                    + ", ".join([path.name for path in intersection])
                 )
                 matrix_jobs.append(matrix_job)
 
@@ -227,9 +231,12 @@ def generate_support_matrix_jobs(
             # name to the list of matrix jobs and move on
             matrix_job = cluster_info.copy()
             matrix_job["upgrade_support"] = "true"
-            matrix_job[
-                "reason_for_support_redeploy"
-            ] = "Support helm chart has been modified"
+
+            if upgrade_support_on_all_clusters:
+                matrix_job[
+                    "reason_for_support_redeploy"
+                ] = "Support helm chart has been modified"
+
             matrix_jobs.append(matrix_job)
 
         else:
@@ -244,8 +251,8 @@ def generate_support_matrix_jobs(
                 matrix_job = cluster_info.copy()
                 matrix_job["upgrade_support"] = "true"
                 matrix_job["reason_for_support_redeploy"] = (
-                    "Following helm chart values files were modified:\n- "
-                    + "\n- ".join([path.name for path in intersection])
+                    "Following helm chart values files were modified: "
+                    + ", ".join([path.name for path in intersection])
                 )
                 matrix_jobs.append(matrix_job)
 
@@ -265,10 +272,10 @@ def assign_staging_matrix_jobs(
     {
         "cluster_name": str                 # Name of the cluster
         "provider": str                     # Name of the cloud provider the cluster runs on
-        "upgrade_support": bool             # Whether to upgrade the support chart for this cluster
+        "upgrade_support": str(bool)        # Whether to upgrade the support chart for this cluster
         "reason_for_support_redeploy": str  # Why the support chart needs to be upgraded
-        "upgrade_staging": bool             # Whether the upgrade the staging deployment on this cluster
-        "reason_for_staging)redeploy": str  # Why the staging hub needs to be upgraded
+        "upgrade_staging": str(bool)        # Whether the upgrade the staging deployment on this cluster
+        "reason_for_staging_redeploy": str  # Why the staging hub needs to be upgraded
     }
 
     Args:
@@ -353,7 +360,7 @@ def assign_staging_matrix_jobs(
                 staging_job["upgrade_staging"] = "true"
                 staging_job[
                     "reason_for_staging_redeploy"
-                ] = "Following prod hubs require redeploy:\n- " + "\n- ".join(
+                ] = "Following prod hubs require redeploy: " + ", ".join(
                     hubs_on_this_cluster
                 )
             else:
@@ -397,7 +404,7 @@ def assign_staging_matrix_jobs(
                 "reason_for_support_redeploy": "",
                 "upgrade_staging": "true",
                 "reason_for_staging_redeploy": (
-                    "Following prod hubs require redeploy:\n- " + "\n- ".join(prod_hubs)
+                    "Following prod hubs require redeploy: " + ", ".join(prod_hubs)
                 ),
             }
 

--- a/mymodule/helm_upgrade_decision_logic.py
+++ b/mymodule/helm_upgrade_decision_logic.py
@@ -555,13 +555,13 @@ def main():
         subprocess.check_call(
             [
                 "echo",
-                f'"::set-output name=PROD_HUB_MATRIX_JOBS::{prod_hub_matrix_jobs}"',
+                f'"::set-output name=prod-hub-matrix-jobs::{yaml.dumps(prod_hub_matrix_jobs)}"',
             ]
         )
         subprocess.check_call(
             [
                 "echo",
-                f'"::set-output name=SUPPORT_AND_STAGING_MATRIX_JOBS::{support_and_staging_matrix_jobs}"',
+                f'"::set-output name=support-and-staging-matrix-jobs::{yaml.dumps(support_and_staging_matrix_jobs)}"',
             ]
         )
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-env =
-    D:RUN_ENV=test

--- a/tests/test-clusters/cluster1/cluster.yaml
+++ b/tests/test-clusters/cluster1/cluster.yaml
@@ -4,6 +4,9 @@ support:
   helm_chart_values_files:
     - support.values.yaml
 hubs:
+  - name: staging
+    helm_chart_values_files:
+      - staging.values.yaml
   - name: hub1
     helm_chart_values_files:
       - hub1.values.yaml

--- a/tests/test-clusters/cluster2/cluster.yaml
+++ b/tests/test-clusters/cluster2/cluster.yaml
@@ -4,6 +4,9 @@ support:
   helm_chart_values_files:
     - support.values.yaml
 hubs:
+  - name: staging
+    helm_chart_values_files:
+      - staging.values.yaml
   - name: hub1
     helm_chart_values_files:
       - hub1.values.yaml

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -2,36 +2,45 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
+from ruamel.yaml import YAML
+
 from mymodule.helm_upgrade_decision_logic import (
+    assign_staging_matrix_jobs,
     discover_modified_common_files,
     generate_hub_matrix_jobs,
-    get_unique_cluster_filepaths,
     generate_support_matrix_jobs,
+    get_all_cluster_yaml_files,
 )
 
+yaml = YAML(typ="safe", pure=True)
 case = TestCase()
 
 
-def test_get_unique_cluster_filepaths():
-    input_filepaths = [
-        os.path.join("tests", "test-clusters", "cluster1", "cluster.yaml"),
-        os.path.join("tests", "test-clusters", "cluster1", "hub1.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster1", "support.values.yaml"),
-    ]
+def test_get_all_cluster_yaml_files():
+    expected_cluster_files = {
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml"),
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster2/cluster.yaml"),
+    }
 
-    # Expected returns
-    expected_cluster_filepaths = [Path("tests/test-clusters/cluster1")]
+    result_cluster_files = get_all_cluster_yaml_files(test_env=True)
 
-    result_cluster_filepaths = get_unique_cluster_filepaths(input_filepaths)
-
-    case.assertCountEqual(result_cluster_filepaths, expected_cluster_filepaths)
-    assert isinstance(result_cluster_filepaths, list)
+    assert result_cluster_files == expected_cluster_files
+    assert isinstance(result_cluster_files, set)
 
 
-def test_generate_hub_matrix_jobs_one_cluster_one_hub():
-    input_cluster_filepaths = [Path("tests/test-clusters/cluster1")]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "hub1.values.yaml")
+def test_generate_hub_matrix_jobs_one_hub():
+    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "",
+    }
+
+    modified_file = {
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
     }
 
     expected_matrix_jobs = [
@@ -39,11 +48,11 @@ def test_generate_hub_matrix_jobs_one_cluster_one_hub():
             "provider": "gcp",
             "cluster_name": "cluster1",
             "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/hub1.values.yaml",
+            "reason_for_redeploy": "Following helm chart values files were modified:\n- hub1.values.yaml",
         }
     ]
 
-    result_matrix_jobs = generate_hub_matrix_jobs(input_cluster_filepaths, input_files)
+    result_matrix_jobs = generate_hub_matrix_jobs(cluster_file, cluster_config, cluster_info, modified_file)
 
     case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
     assert isinstance(result_matrix_jobs, list)
@@ -55,11 +64,20 @@ def test_generate_hub_matrix_jobs_one_cluster_one_hub():
     assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
 
 
-def test_generate_hub_matrix_jobs_one_cluster_many_hubs():
-    input_cluster_filepaths = [Path("tests/test-clusters/cluster1")]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "hub1.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster1", "hub2.values.yaml"),
+def test_generate_hub_matrix_jobs_many_hubs():
+    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "",
+    }
+
+    modified_files = {
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub2.values.yaml"),
     }
 
     expected_matrix_jobs = [
@@ -67,200 +85,21 @@ def test_generate_hub_matrix_jobs_one_cluster_many_hubs():
             "provider": "gcp",
             "cluster_name": "cluster1",
             "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/hub1.values.yaml",
+            "reason_for_redeploy": "Following helm chart values files were modified:\n- hub1.values.yaml",
         },
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
             "hub_name": "hub2",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/hub2.values.yaml",
-        },
-    ]
-
-    result_matrix_jobs = generate_hub_matrix_jobs(input_cluster_filepaths, input_files)
-
-    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs, list)
-    assert isinstance(result_matrix_jobs[0], dict)
-
-    assert "provider" in result_matrix_jobs[0].keys()
-    assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "hub_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
-
-
-def test_generate_hub_matrix_jobs_one_cluster_all_hubs():
-    input_cluster_filepaths = [Path("tests/test-clusters/cluster1")]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "hub1.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster1", "cluster.yaml"),
-    }
-
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub2",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub3",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
-    ]
-
-    result_matrix_jobs = generate_hub_matrix_jobs(input_cluster_filepaths, input_files)
-
-    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs, list)
-    assert isinstance(result_matrix_jobs[0], dict)
-
-    assert "provider" in result_matrix_jobs[0].keys()
-    assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "hub_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
-
-
-def test_generate_hub_matrix_jobs_many_clusters_one_hub():
-    input_cluster_filepaths = [
-        Path("tests/test-clusters/cluster1"),
-        Path("tests/test-clusters/cluster2"),
-    ]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "hub1.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster2", "hub1.values.yaml"),
-    }
-
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/hub1.values.yaml",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster2/hub1.values.yaml",
-        },
-    ]
-
-    result_matrix_jobs = generate_hub_matrix_jobs(input_cluster_filepaths, input_files)
-
-    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs, list)
-    assert isinstance(result_matrix_jobs[0], dict)
-
-    assert "provider" in result_matrix_jobs[0].keys()
-    assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "hub_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
-
-
-def test_generate_hub_matrix_jobs_many_clusters_many_hubs():
-    input_cluster_filepaths = [
-        Path("tests/test-clusters/cluster1"),
-        Path("tests/test-clusters/cluster2"),
-    ]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "hub1.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster1", "hub2.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster2", "hub1.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster2", "hub2.values.yaml"),
-    }
-
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/hub1.values.yaml",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub2",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/hub2.values.yaml",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster2/hub1.values.yaml",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "hub_name": "hub2",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster2/hub2.values.yaml",
-        },
-    ]
-
-    result_matrix_jobs = generate_hub_matrix_jobs(input_cluster_filepaths, input_files)
-
-    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs, list)
-    assert isinstance(result_matrix_jobs[0], dict)
-
-    assert "provider" in result_matrix_jobs[0].keys()
-    assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "hub_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
-
-
-def test_generate_hub_matrix_jobs_all_clusters_all_hubs():
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "Core infrastructure has changed",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub2",
-            "reason_for_redeploy": "Core infrastructure has changed",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub3",
-            "reason_for_redeploy": "Core infrastructure has changed",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "Core infrastructure has changed",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "hub_name": "hub2",
-            "reason_for_redeploy": "Core infrastructure has changed",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "hub_name": "hub3",
-            "reason_for_redeploy": "Core infrastructure has changed",
+            "reason_for_redeploy": "Following helm chart values files were modified:\n- hub2.values.yaml",
         },
     ]
 
     result_matrix_jobs = generate_hub_matrix_jobs(
-        [],
-        set(),
-        upgrade_all_hubs_on_all_clusters=True,
+        cluster_file,
+        cluster_config,
+        cluster_info,
+        modified_files,
     )
 
     case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
@@ -273,23 +112,125 @@ def test_generate_hub_matrix_jobs_all_clusters_all_hubs():
     assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
 
 
-def test_generate_support_matrix_jobs_one_cluster():
-    input_cluster_filepaths = [Path("tests/test-clusters/cluster1")]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "support.values.yaml"),
+def test_generate_hub_matrix_jobs_all_hubs():
+    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "cluster.yaml file was modified",
+    }
+
+    modified_files = {
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml"),
     }
 
     expected_matrix_jobs = [
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/support.values.yaml",
+            "hub_name": "staging",
+            "reason_for_redeploy": "cluster.yaml file was modified",
+        },
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "hub_name": "hub1",
+            "reason_for_redeploy": "cluster.yaml file was modified",
+        },
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "hub_name": "hub2",
+            "reason_for_redeploy": "cluster.yaml file was modified",
+        },
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "hub_name": "hub3",
+            "reason_for_redeploy": "cluster.yaml file was modified",
+        },
+    ]
+
+    result_matrix_jobs_1 = generate_hub_matrix_jobs(
+        cluster_file,
+        cluster_config,
+        cluster_info,
+        modified_files,
+        upgrade_all_hubs_on_this_cluster=True,
+    )
+    result_matrix_jobs_2 = generate_hub_matrix_jobs(
+        cluster_file,
+        cluster_config,
+        cluster_info,
+        modified_files,
+        upgrade_all_hubs_on_all_clusters=True,
+    )
+    result_matrix_jobs_3 = generate_hub_matrix_jobs(
+        cluster_file,
+        cluster_config,
+        cluster_info,
+        modified_files,
+        upgrade_all_hubs_on_this_cluster=True,
+        upgrade_all_hubs_on_all_clusters=True,
+    )
+
+    case.assertCountEqual(result_matrix_jobs_1, expected_matrix_jobs)
+    assert isinstance(result_matrix_jobs_1, list)
+    assert isinstance(result_matrix_jobs_1[0], dict)
+
+    case.assertCountEqual(result_matrix_jobs_2, expected_matrix_jobs)
+    assert isinstance(result_matrix_jobs_2, list)
+    assert isinstance(result_matrix_jobs_2[0], dict)
+
+    case.assertCountEqual(result_matrix_jobs_3, expected_matrix_jobs)
+    assert isinstance(result_matrix_jobs_3, list)
+    assert isinstance(result_matrix_jobs_3[0], dict)
+
+    assert "provider" in result_matrix_jobs_1[0].keys()
+    assert "cluster_name" in result_matrix_jobs_1[0].keys()
+    assert "hub_name" in result_matrix_jobs_1[0].keys()
+    assert "reason_for_redeploy" in result_matrix_jobs_1[0].keys()
+
+    assert "provider" in result_matrix_jobs_2[0].keys()
+    assert "cluster_name" in result_matrix_jobs_2[0].keys()
+    assert "hub_name" in result_matrix_jobs_2[0].keys()
+    assert "reason_for_redeploy" in result_matrix_jobs_2[0].keys()
+
+    assert "provider" in result_matrix_jobs_3[0].keys()
+    assert "cluster_name" in result_matrix_jobs_3[0].keys()
+    assert "hub_name" in result_matrix_jobs_3[0].keys()
+    assert "reason_for_redeploy" in result_matrix_jobs_3[0].keys()
+
+
+def test_generate_support_matrix_jobs_one_cluster():
+    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "",
+    }
+
+    modified_file = {
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/support.values.yaml"),
+    }
+
+    expected_matrix_jobs = [
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "upgrade_support": True,
+            "reason_for_support_redeploy": "Following helm chart values files were modified:\n- support.values.yaml",
         }
     ]
 
-    result_matrix_jobs = generate_support_matrix_jobs(
-        input_cluster_filepaths, input_files
-    )
+    result_matrix_jobs = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info, modified_file)
 
     case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
     assert isinstance(result_matrix_jobs, list)
@@ -297,70 +238,68 @@ def test_generate_support_matrix_jobs_one_cluster():
 
     assert "provider" in result_matrix_jobs[0].keys()
     assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
+    assert "upgrade_support" in result_matrix_jobs[0].keys()
+    assert "reason_for_support_redeploy" in result_matrix_jobs[0].keys()
+    assert result_matrix_jobs[0]["upgrade_support"]
 
 
-def test_generate_support_matrix_jobs_many_clusters():
-    input_cluster_filepaths = [
-        Path("tests/test-clusters/cluster1"),
-        Path("tests/test-clusters/cluster2"),
-    ]
-    input_files = {
-        os.path.join("tests", "test-clusters", "cluster1", "support.values.yaml"),
-        os.path.join("tests", "test-clusters", "cluster2", "support.values.yaml"),
+def test_generate_support_matrix_jobs_all_clusters():
+    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    with open(cluster_file) as f:
+        cluster_config = yaml.load(f)
+
+    cluster_info = {
+        "cluster_name": cluster_config.get("name", {}),
+        "provider": cluster_config.get("provider", {}),
+        "reason_for_redeploy": "",
+    }
+
+    modified_file = {
+        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/support.values.yaml"),
     }
 
     expected_matrix_jobs = [
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster1/support.values.yaml",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "reason_for_redeploy": "Following helm chart values files were modified:\ntests/test-clusters/cluster2/support.values.yaml",
-        },
+            "upgrade_support": True,
+            "reason_for_support_redeploy": "Support helm chart has been modified",
+        }
     ]
 
-    result_matrix_jobs = generate_support_matrix_jobs(
-        input_cluster_filepaths, input_files
-    )
+    result_matrix_jobs_1 = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info.copy(), modified_file, upgrade_support_on_this_cluster=True)
+    result_matrix_jobs_2 = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info.copy(), modified_file, upgrade_support_on_all_clusters=True)
+    result_matrix_jobs_3 = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info.copy(), modified_file, upgrade_support_on_this_cluster=True, upgrade_support_on_all_clusters=True)
 
-    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs, list)
-    assert isinstance(result_matrix_jobs[0], dict)
+    case.assertCountEqual(result_matrix_jobs_1, expected_matrix_jobs)
+    assert isinstance(result_matrix_jobs_1, list)
+    assert isinstance(result_matrix_jobs_1[0], dict)
 
-    assert "provider" in result_matrix_jobs[0].keys()
-    assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
+    case.assertCountEqual(result_matrix_jobs_2, expected_matrix_jobs)
+    assert isinstance(result_matrix_jobs_2, list)
+    assert isinstance(result_matrix_jobs_2[0], dict)
 
+    case.assertCountEqual(result_matrix_jobs_3, expected_matrix_jobs)
+    assert isinstance(result_matrix_jobs_3, list)
+    assert isinstance(result_matrix_jobs_3[0], dict)
 
-def test_generate_support_matrix_jobs_all_clusters():
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "reason_for_redeploy": "Support helm chart has been modified",
-        },
-        {
-            "provider": "aws",
-            "cluster_name": "cluster2",
-            "reason_for_redeploy": "Support helm chart has been modified",
-        },
-    ]
+    assert "provider" in result_matrix_jobs_1[0].keys()
+    assert "cluster_name" in result_matrix_jobs_1[0].keys()
+    assert "upgrade_support" in result_matrix_jobs_1[0].keys()
+    assert "reason_for_support_redeploy" in result_matrix_jobs_1[0].keys()
+    assert result_matrix_jobs_1[0]["upgrade_support"]
 
-    result_matrix_jobs = generate_support_matrix_jobs(
-        [], set(), upgrade_support_on_all_clusters=True
-    )
+    assert "provider" in result_matrix_jobs_2[0].keys()
+    assert "cluster_name" in result_matrix_jobs_2[0].keys()
+    assert "upgrade_support" in result_matrix_jobs_2[0].keys()
+    assert "reason_for_support_redeploy" in result_matrix_jobs_2[0].keys()
+    assert result_matrix_jobs_2[0]["upgrade_support"]
 
-    case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs, list)
-    assert isinstance(result_matrix_jobs[0], dict)
-
-    assert "provider" in result_matrix_jobs[0].keys()
-    assert "cluster_name" in result_matrix_jobs[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
+    assert "provider" in result_matrix_jobs_3[0].keys()
+    assert "cluster_name" in result_matrix_jobs_3[0].keys()
+    assert "upgrade_support" in result_matrix_jobs_3[0].keys()
+    assert "reason_for_support_redeploy" in result_matrix_jobs_3[0].keys()
+    assert result_matrix_jobs_3[0]["upgrade_support"]
 
 
 def test_discover_modified_common_files_hub_helm_charts():
@@ -383,9 +322,9 @@ def test_discover_modified_common_files_hub_helm_charts():
 
 
 def test_discover_modified_common_files_support_helm_chart():
-    input_path = [os.path.join("helm-charts", "support", "Chart.yaml")]
+    modified_files = [os.path.join("helm-charts", "support", "Chart.yaml")]
 
-    upgrade_all_clusters, upgrade_all_hubs = discover_modified_common_files(input_path)
+    upgrade_all_clusters, upgrade_all_hubs = discover_modified_common_files(modified_files)
 
     assert upgrade_all_clusters
     assert not upgrade_all_hubs

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -235,7 +235,7 @@ def test_generate_support_matrix_jobs_one_cluster():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": True,
+            "upgrade_support": "true",
             "reason_for_support_redeploy": "Following helm chart values files were modified:\n- support.values.yaml",
         }
     ]
@@ -252,7 +252,7 @@ def test_generate_support_matrix_jobs_one_cluster():
     assert "cluster_name" in result_matrix_jobs[0].keys()
     assert "upgrade_support" in result_matrix_jobs[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs[0].keys()
-    assert result_matrix_jobs[0]["upgrade_support"]
+    assert result_matrix_jobs[0]["upgrade_support"] == "true"
 
 
 def test_generate_support_matrix_jobs_all_clusters():
@@ -276,7 +276,7 @@ def test_generate_support_matrix_jobs_all_clusters():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": True,
+            "upgrade_support": "true",
             "reason_for_support_redeploy": "Support helm chart has been modified",
         }
     ]
@@ -320,19 +320,19 @@ def test_generate_support_matrix_jobs_all_clusters():
     assert "cluster_name" in result_matrix_jobs_1[0].keys()
     assert "upgrade_support" in result_matrix_jobs_1[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs_1[0].keys()
-    assert result_matrix_jobs_1[0]["upgrade_support"]
+    assert result_matrix_jobs_1[0]["upgrade_support"] == "true"
 
     assert "provider" in result_matrix_jobs_2[0].keys()
     assert "cluster_name" in result_matrix_jobs_2[0].keys()
     assert "upgrade_support" in result_matrix_jobs_2[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs_2[0].keys()
-    assert result_matrix_jobs_2[0]["upgrade_support"]
+    assert result_matrix_jobs_2[0]["upgrade_support"] == "true"
 
     assert "provider" in result_matrix_jobs_3[0].keys()
     assert "cluster_name" in result_matrix_jobs_3[0].keys()
     assert "upgrade_support" in result_matrix_jobs_3[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs_3[0].keys()
-    assert result_matrix_jobs_3[0]["upgrade_support"]
+    assert result_matrix_jobs_3[0]["upgrade_support"] == "true"
 
 
 def test_discover_modified_common_files_hub_helm_charts():

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -131,87 +131,58 @@ def test_generate_hub_matrix_jobs_all_hubs():
         "reason_for_redeploy": "cluster.yaml file was modified",
     }
 
-    modified_files = {
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/hub1.values.yaml"),
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml"),
-    }
-
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "staging",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub1",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub2",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "hub_name": "hub3",
-            "reason_for_redeploy": "cluster.yaml file was modified",
-        },
+    reasons = [
+        "cluster.yaml file was modified",
+        "Core infrastructure has been modified",
+        "Core infrastructure has been modified",
     ]
+    bool_options = [(True, False), (False, True), (True, True)]
 
-    result_matrix_jobs_1 = generate_hub_matrix_jobs(
-        cluster_file,
-        cluster_config,
-        cluster_info,
-        modified_files,
-        upgrade_all_hubs_on_this_cluster=True,
-    )
-    result_matrix_jobs_2 = generate_hub_matrix_jobs(
-        cluster_file,
-        cluster_config,
-        cluster_info,
-        modified_files,
-        upgrade_all_hubs_on_all_clusters=True,
-    )
-    result_matrix_jobs_3 = generate_hub_matrix_jobs(
-        cluster_file,
-        cluster_config,
-        cluster_info,
-        modified_files,
-        upgrade_all_hubs_on_this_cluster=True,
-        upgrade_all_hubs_on_all_clusters=True,
-    )
+    for reason, bool_option in zip(reasons, bool_options):
+        expected_matrix_jobs = [
+            {
+                "provider": "gcp",
+                "cluster_name": "cluster1",
+                "hub_name": "staging",
+                "reason_for_redeploy": reason,
+            },
+            {
+                "provider": "gcp",
+                "cluster_name": "cluster1",
+                "hub_name": "hub1",
+                "reason_for_redeploy": reason,
+            },
+            {
+                "provider": "gcp",
+                "cluster_name": "cluster1",
+                "hub_name": "hub2",
+                "reason_for_redeploy": reason,
+            },
+            {
+                "provider": "gcp",
+                "cluster_name": "cluster1",
+                "hub_name": "hub3",
+                "reason_for_redeploy": reason,
+            },
+        ]
 
-    case.assertCountEqual(result_matrix_jobs_1, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs_1, list)
-    assert isinstance(result_matrix_jobs_1[0], dict)
+        result_matrix_jobs = generate_hub_matrix_jobs(
+            cluster_file,
+            cluster_config,
+            cluster_info,
+            set(),
+            upgrade_all_hubs_on_this_cluster=bool_option[0],
+            upgrade_all_hubs_on_all_clusters=bool_option[1],
+        )
 
-    case.assertCountEqual(result_matrix_jobs_2, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs_2, list)
-    assert isinstance(result_matrix_jobs_2[0], dict)
+        case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
+        assert isinstance(result_matrix_jobs, list)
+        assert isinstance(result_matrix_jobs[0], dict)
 
-    case.assertCountEqual(result_matrix_jobs_3, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs_3, list)
-    assert isinstance(result_matrix_jobs_3[0], dict)
-
-    assert "provider" in result_matrix_jobs_1[0].keys()
-    assert "cluster_name" in result_matrix_jobs_1[0].keys()
-    assert "hub_name" in result_matrix_jobs_1[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs_1[0].keys()
-
-    assert "provider" in result_matrix_jobs_2[0].keys()
-    assert "cluster_name" in result_matrix_jobs_2[0].keys()
-    assert "hub_name" in result_matrix_jobs_2[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs_2[0].keys()
-
-    assert "provider" in result_matrix_jobs_3[0].keys()
-    assert "cluster_name" in result_matrix_jobs_3[0].keys()
-    assert "hub_name" in result_matrix_jobs_3[0].keys()
-    assert "reason_for_redeploy" in result_matrix_jobs_3[0].keys()
+        assert "provider" in result_matrix_jobs[0].keys()
+        assert "cluster_name" in result_matrix_jobs[0].keys()
+        assert "hub_name" in result_matrix_jobs[0].keys()
+        assert "reason_for_redeploy" in result_matrix_jobs[0].keys()
 
 
 def test_generate_support_matrix_jobs_one_cluster():
@@ -252,7 +223,6 @@ def test_generate_support_matrix_jobs_one_cluster():
     assert "cluster_name" in result_matrix_jobs[0].keys()
     assert "upgrade_support" in result_matrix_jobs[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs[0].keys()
-    assert result_matrix_jobs[0]["upgrade_support"] == "true"
 
 
 def test_generate_support_matrix_jobs_all_clusters():
@@ -265,74 +235,43 @@ def test_generate_support_matrix_jobs_all_clusters():
     cluster_info = {
         "cluster_name": cluster_config.get("name", {}),
         "provider": cluster_config.get("provider", {}),
-        "reason_for_redeploy": "",
+        "reason_for_redeploy": "cluster.yaml file was modified",
     }
 
-    modified_file = {
-        Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/support.values.yaml"),
-    }
-
-    expected_matrix_jobs = [
-        {
-            "provider": "gcp",
-            "cluster_name": "cluster1",
-            "upgrade_support": "true",
-            "reason_for_support_redeploy": "Support helm chart has been modified",
-        }
+    reasons = [
+        "cluster.yaml file was modified",
+        "Support helm chart has been modified",
+        "Support helm chart has been modified",
     ]
+    bool_options = [(True, False), (False, True), (True, True)]
 
-    result_matrix_jobs_1 = generate_support_matrix_jobs(
-        cluster_file,
-        cluster_config,
-        cluster_info.copy(),
-        modified_file,
-        upgrade_support_on_this_cluster=True,
-    )
-    result_matrix_jobs_2 = generate_support_matrix_jobs(
-        cluster_file,
-        cluster_config,
-        cluster_info.copy(),
-        modified_file,
-        upgrade_support_on_all_clusters=True,
-    )
-    result_matrix_jobs_3 = generate_support_matrix_jobs(
-        cluster_file,
-        cluster_config,
-        cluster_info.copy(),
-        modified_file,
-        upgrade_support_on_this_cluster=True,
-        upgrade_support_on_all_clusters=True,
-    )
+    for reason, bool_option in zip(reasons, bool_options):
+        expected_matrix_jobs = [
+            {
+                "provider": "gcp",
+                "cluster_name": "cluster1",
+                "upgrade_support": "true",
+                "reason_for_support_redeploy": reason,
+            }
+        ]
 
-    case.assertCountEqual(result_matrix_jobs_1, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs_1, list)
-    assert isinstance(result_matrix_jobs_1[0], dict)
+        result_matrix_jobs = generate_support_matrix_jobs(
+            cluster_file,
+            cluster_config,
+            cluster_info.copy(),
+            set(),
+            upgrade_support_on_this_cluster=bool_option[0],
+            upgrade_support_on_all_clusters=bool_option[1],
+        )
 
-    case.assertCountEqual(result_matrix_jobs_2, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs_2, list)
-    assert isinstance(result_matrix_jobs_2[0], dict)
+        case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
+        assert isinstance(result_matrix_jobs, list)
+        assert isinstance(result_matrix_jobs[0], dict)
 
-    case.assertCountEqual(result_matrix_jobs_3, expected_matrix_jobs)
-    assert isinstance(result_matrix_jobs_3, list)
-    assert isinstance(result_matrix_jobs_3[0], dict)
-
-    assert "provider" in result_matrix_jobs_1[0].keys()
-    assert "cluster_name" in result_matrix_jobs_1[0].keys()
-    assert "upgrade_support" in result_matrix_jobs_1[0].keys()
-    assert "reason_for_support_redeploy" in result_matrix_jobs_1[0].keys()
-    assert result_matrix_jobs_1[0]["upgrade_support"] == "true"
-
-    assert "provider" in result_matrix_jobs_2[0].keys()
-    assert "cluster_name" in result_matrix_jobs_2[0].keys()
-    assert "upgrade_support" in result_matrix_jobs_2[0].keys()
-    assert "reason_for_support_redeploy" in result_matrix_jobs_2[0].keys()
-    assert result_matrix_jobs_2[0]["upgrade_support"] == "true"
-
-    assert "provider" in result_matrix_jobs_3[0].keys()
-    assert "cluster_name" in result_matrix_jobs_3[0].keys()
-    assert "upgrade_support" in result_matrix_jobs_3[0].keys()
-    assert "reason_for_support_redeploy" in result_matrix_jobs_3[0].keys()
-    assert result_matrix_jobs_3[0]["upgrade_support"] == "true"
+        assert "provider" in result_matrix_jobs[0].keys()
+        assert "cluster_name" in result_matrix_jobs[0].keys()
+        assert "upgrade_support" in result_matrix_jobs[0].keys()
+        assert "reason_for_support_redeploy" in result_matrix_jobs[0].keys()
 
 
 def test_discover_modified_common_files_hub_helm_charts():

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -29,7 +29,9 @@ def test_get_all_cluster_yaml_files():
 
 
 def test_generate_hub_matrix_jobs_one_hub():
-    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    cluster_file = Path(os.getcwd()).joinpath(
+        "tests/test-clusters/cluster1/cluster.yaml"
+    )
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -52,7 +54,9 @@ def test_generate_hub_matrix_jobs_one_hub():
         }
     ]
 
-    result_matrix_jobs = generate_hub_matrix_jobs(cluster_file, cluster_config, cluster_info, modified_file)
+    result_matrix_jobs = generate_hub_matrix_jobs(
+        cluster_file, cluster_config, cluster_info, modified_file
+    )
 
     case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
     assert isinstance(result_matrix_jobs, list)
@@ -65,7 +69,9 @@ def test_generate_hub_matrix_jobs_one_hub():
 
 
 def test_generate_hub_matrix_jobs_many_hubs():
-    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    cluster_file = Path(os.getcwd()).joinpath(
+        "tests/test-clusters/cluster1/cluster.yaml"
+    )
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -113,7 +119,9 @@ def test_generate_hub_matrix_jobs_many_hubs():
 
 
 def test_generate_hub_matrix_jobs_all_hubs():
-    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    cluster_file = Path(os.getcwd()).joinpath(
+        "tests/test-clusters/cluster1/cluster.yaml"
+    )
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -207,7 +215,9 @@ def test_generate_hub_matrix_jobs_all_hubs():
 
 
 def test_generate_support_matrix_jobs_one_cluster():
-    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    cluster_file = Path(os.getcwd()).joinpath(
+        "tests/test-clusters/cluster1/cluster.yaml"
+    )
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -230,7 +240,9 @@ def test_generate_support_matrix_jobs_one_cluster():
         }
     ]
 
-    result_matrix_jobs = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info, modified_file)
+    result_matrix_jobs = generate_support_matrix_jobs(
+        cluster_file, cluster_config, cluster_info, modified_file
+    )
 
     case.assertCountEqual(result_matrix_jobs, expected_matrix_jobs)
     assert isinstance(result_matrix_jobs, list)
@@ -244,7 +256,9 @@ def test_generate_support_matrix_jobs_one_cluster():
 
 
 def test_generate_support_matrix_jobs_all_clusters():
-    cluster_file = Path(os.getcwd()).joinpath("tests/test-clusters/cluster1/cluster.yaml")
+    cluster_file = Path(os.getcwd()).joinpath(
+        "tests/test-clusters/cluster1/cluster.yaml"
+    )
     with open(cluster_file) as f:
         cluster_config = yaml.load(f)
 
@@ -267,9 +281,28 @@ def test_generate_support_matrix_jobs_all_clusters():
         }
     ]
 
-    result_matrix_jobs_1 = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info.copy(), modified_file, upgrade_support_on_this_cluster=True)
-    result_matrix_jobs_2 = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info.copy(), modified_file, upgrade_support_on_all_clusters=True)
-    result_matrix_jobs_3 = generate_support_matrix_jobs(cluster_file, cluster_config, cluster_info.copy(), modified_file, upgrade_support_on_this_cluster=True, upgrade_support_on_all_clusters=True)
+    result_matrix_jobs_1 = generate_support_matrix_jobs(
+        cluster_file,
+        cluster_config,
+        cluster_info.copy(),
+        modified_file,
+        upgrade_support_on_this_cluster=True,
+    )
+    result_matrix_jobs_2 = generate_support_matrix_jobs(
+        cluster_file,
+        cluster_config,
+        cluster_info.copy(),
+        modified_file,
+        upgrade_support_on_all_clusters=True,
+    )
+    result_matrix_jobs_3 = generate_support_matrix_jobs(
+        cluster_file,
+        cluster_config,
+        cluster_info.copy(),
+        modified_file,
+        upgrade_support_on_this_cluster=True,
+        upgrade_support_on_all_clusters=True,
+    )
 
     case.assertCountEqual(result_matrix_jobs_1, expected_matrix_jobs)
     assert isinstance(result_matrix_jobs_1, list)
@@ -324,7 +357,9 @@ def test_discover_modified_common_files_hub_helm_charts():
 def test_discover_modified_common_files_support_helm_chart():
     modified_files = [os.path.join("helm-charts", "support", "Chart.yaml")]
 
-    upgrade_all_clusters, upgrade_all_hubs = discover_modified_common_files(modified_files)
+    upgrade_all_clusters, upgrade_all_hubs = discover_modified_common_files(
+        modified_files
+    )
 
     assert upgrade_all_clusters
     assert not upgrade_all_hubs

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -50,7 +50,7 @@ def test_generate_hub_matrix_jobs_one_hub():
             "provider": "gcp",
             "cluster_name": "cluster1",
             "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\n- hub1.values.yaml",
+            "reason_for_redeploy": "Following helm chart values files were modified: hub1.values.yaml",
         }
     ]
 
@@ -91,13 +91,13 @@ def test_generate_hub_matrix_jobs_many_hubs():
             "provider": "gcp",
             "cluster_name": "cluster1",
             "hub_name": "hub1",
-            "reason_for_redeploy": "Following helm chart values files were modified:\n- hub1.values.yaml",
+            "reason_for_redeploy": "Following helm chart values files were modified: hub1.values.yaml",
         },
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
             "hub_name": "hub2",
-            "reason_for_redeploy": "Following helm chart values files were modified:\n- hub2.values.yaml",
+            "reason_for_redeploy": "Following helm chart values files were modified: hub2.values.yaml",
         },
     ]
 
@@ -236,7 +236,7 @@ def test_generate_support_matrix_jobs_one_cluster():
             "provider": "gcp",
             "cluster_name": "cluster1",
             "upgrade_support": "true",
-            "reason_for_support_redeploy": "Following helm chart values files were modified:\n- support.values.yaml",
+            "reason_for_support_redeploy": "Following helm chart values files were modified: support.values.yaml",
         }
     ]
 

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from ruamel.yaml import YAML
 
 from mymodule.helm_upgrade_decision_logic import (
+    assign_staging_jobs_for_missing_clusters,
     discover_modified_common_files,
     ensure_support_staging_jobs_have_correct_keys,
     generate_hub_matrix_jobs,
@@ -476,6 +477,71 @@ def test_ensure_support_staging_jobs_have_correct_keys_hubs_dont_exist():
 
     result_support_staging_jobs = ensure_support_staging_jobs_have_correct_keys(
         input_support_staging_jobs, []
+    )
+
+    case.assertCountEqual(result_support_staging_jobs, expected_support_staging_jobs)
+
+
+def test_assign_staging_jobs_for_missing_clusters_is_missing():
+    input_prod_jobs = [
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "hub_name": "hub1",
+        },
+    ]
+
+    expected_support_staging_jobs = [
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "upgrade_support": "false",
+            "reason_for_support_redeploy": "",
+            "upgrade_staging": "true",
+            "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
+        }
+    ]
+
+    result_support_staging_jobs = assign_staging_jobs_for_missing_clusters(
+        [], input_prod_jobs
+    )
+
+    case.assertCountEqual(result_support_staging_jobs, expected_support_staging_jobs)
+
+
+def test_assign_staging_jobs_for_missing_clusters_is_present():
+    input_prod_jobs = [
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "hub_name": "hub1",
+        },
+    ]
+
+    input_support_staging_jobs = [
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "upgrade_support": "false",
+            "reason_for_support_redeploy": "",
+            "upgrade_staging": "true",
+            "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
+        }
+    ]
+
+    expected_support_staging_jobs = [
+        {
+            "provider": "gcp",
+            "cluster_name": "cluster1",
+            "upgrade_support": "false",
+            "reason_for_support_redeploy": "",
+            "upgrade_staging": "true",
+            "reason_for_staging_redeploy": "Following prod hubs require redeploy: hub1",
+        }
+    ]
+
+    result_support_staging_jobs = assign_staging_jobs_for_missing_clusters(
+        input_support_staging_jobs, input_prod_jobs
     )
 
     case.assertCountEqual(result_support_staging_jobs, expected_support_staging_jobs)

--- a/tests/test_helm_upgrade_decision_logic.py
+++ b/tests/test_helm_upgrade_decision_logic.py
@@ -235,7 +235,7 @@ def test_generate_support_matrix_jobs_one_cluster():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": "true",
+            "upgrade_support": True,
             "reason_for_support_redeploy": "Following helm chart values files were modified:\n- support.values.yaml",
         }
     ]
@@ -252,7 +252,7 @@ def test_generate_support_matrix_jobs_one_cluster():
     assert "cluster_name" in result_matrix_jobs[0].keys()
     assert "upgrade_support" in result_matrix_jobs[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs[0].keys()
-    assert result_matrix_jobs[0]["upgrade_support"] == "true"
+    assert result_matrix_jobs[0]["upgrade_support"]
 
 
 def test_generate_support_matrix_jobs_all_clusters():
@@ -276,7 +276,7 @@ def test_generate_support_matrix_jobs_all_clusters():
         {
             "provider": "gcp",
             "cluster_name": "cluster1",
-            "upgrade_support": "true",
+            "upgrade_support": True,
             "reason_for_support_redeploy": "Support helm chart has been modified",
         }
     ]
@@ -320,19 +320,19 @@ def test_generate_support_matrix_jobs_all_clusters():
     assert "cluster_name" in result_matrix_jobs_1[0].keys()
     assert "upgrade_support" in result_matrix_jobs_1[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs_1[0].keys()
-    assert result_matrix_jobs_1[0]["upgrade_support"] == "true"
+    assert result_matrix_jobs_1[0]["upgrade_support"]
 
     assert "provider" in result_matrix_jobs_2[0].keys()
     assert "cluster_name" in result_matrix_jobs_2[0].keys()
     assert "upgrade_support" in result_matrix_jobs_2[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs_2[0].keys()
-    assert result_matrix_jobs_2[0]["upgrade_support"] == "true"
+    assert result_matrix_jobs_2[0]["upgrade_support"]
 
     assert "provider" in result_matrix_jobs_3[0].keys()
     assert "cluster_name" in result_matrix_jobs_3[0].keys()
     assert "upgrade_support" in result_matrix_jobs_3[0].keys()
     assert "reason_for_support_redeploy" in result_matrix_jobs_3[0].keys()
-    assert result_matrix_jobs_3[0]["upgrade_support"] == "true"
+    assert result_matrix_jobs_3[0]["upgrade_support"]
 
 
 def test_discover_modified_common_files_hub_helm_charts():


### PR DESCRIPTION
### Using job outputs instead of environment variables

Two key concepts to understand:

- Different jobs run on different GitHub Action runners, even if they are defined in the same GitHub Action workflow file
- Environment variables are written to a file located at `GITHUB_ENV` and this is not shared between jobs since it is local to the runner

For these reasons, we cannot create an environment variable in one job and use it in a second job downstream of the first.

Instead, we can set job outputs which _are_ shared between jobs, regardless of runner!

### Refactor the structure of jobs

We create two lists of dictionaries that represent matrix jobs for a GitHub Actions job to run in parallel. These are:

- `support_and_staging_matrix_jobs` that is parsed to the `support-staging-jobs` job to upgrade the support chart and staging deployment, if required

  Its structure is:

  ```yaml
  {
    "provider": str                     # The cloud provider the given cluster runs on
    "cluster_name": str                 # The name of the given cluster
    "upgrade_support": str(bool)        # String representation of a Boolean. Whether to upgrade the support chart for this cluster.
    "reason_for_support_redeploy": str  # Why the support chart needs redeploying
    "upgrade_staging": str(bool)        # String representation of a Boolean. Whether to upgrade the staging hub for this cluster.
    "reason_for_staging_redeploy": str  # Why the staging hub needs redeploying
  }
  ```

  **Note:** These must be string representation of Booleans for the GitHub Action runner to parse them correctly

- `prod_hub_matrix_jobs` that is parsed to the `hub-jobs` job to upgrade the production hubs

  Its structure is:

  ```yaml
  {
    "provider": str             # The cloud provider the given cluster runs on
    "cluster_name": str         # The name of the given cluster
    "hub_name": str             # The name of a given prod hub on the given cluster that requires upgrading
    "reason_for_redeploy": str  # Why this prod hub needs redeploying
  }
  ```